### PR TITLE
Update to spatial hydrology function examples, minor bug fixes

### DIFF
--- a/R/ch_checkcatchment.R
+++ b/R/ch_checkcatchment.R
@@ -16,8 +16,39 @@
 #' @seealso \code{\link{ch_saga_fillsinks}} to fill sinks instead of removing
 #' 
 #' @examples
+#' 
 #' \dontrun{
-#' ch_checkcatchment()
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires multiple potentially lengthy GIS operations
+#' 
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # fill sinks
+#' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
+#' 
+#' # download station locations (use as catchment outlets)
+#' ff <- "gs_weirs.GeoJSON"
+#' gs_fn <- file.path(saga_wd, ff)
+#' gs_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' stns <- ch_get_url_data(gs_url, gs_fn)
+#' 
+#' # determine contributing area raster using filled_dem
+#' carea <- ch_saga_carea(filled_dem, saga_wd)
+#' 
+#' # run catchment delineation
+#' catchments <-  ch_saga_catchment(dem=dem, saga_wd=saga_wd, outlet=stns, carea=carea)
+#' 
+#' # check catchments
+#' ch_checkcatchment(filled_dem, catchments, stns)
 #' }
 #' 
 #' @importFrom sf st_bbox st_area
@@ -47,7 +78,7 @@ ch_checkcatchment <- function(dem, catchment, outlet, outlet_label = NULL) {
     theme_bw()
   
   print(check_map)
-  nc <- length(catchment)
+  nc <- nrow(catchment)
   
   # print catchment area with units
   if (is.null(outlet_label)) {
@@ -60,7 +91,7 @@ ch_checkcatchment <- function(dem, catchment, outlet, outlet_label = NULL) {
   units <- rep(paste0(attr(area, "units")$numerator[1], "^2"), length(area))
   value <- round(as.numeric(area))
   area_df <- outlet %>%
-    mutate(label = labels, area = value, units = units)
+    mutate(label = labels, area = value, area_units = units)
   
   return(area_df)
 }

--- a/R/ch_checkcatchment.R
+++ b/R/ch_checkcatchment.R
@@ -25,9 +25,9 @@
 #' 
 #' # create saga wd using base::tempdir()
 #' saga_wd <- tempdir()
-#'
-#' # download 25m DEM
-#' ff <- "gs_dem25.tif"
+#' 
+#' # download LiDAR DEM for 240 and 241 creek
+#' ff <- "gs_be240.tif"
 #' ra_fn <- file.path(saga_wd, ff)
 #' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
 #' dem <- ch_get_url_data(ra_url, ra_fn)
@@ -35,17 +35,17 @@
 #' # fill sinks
 #' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
 #' 
-#' # download station locations (use as catchment outlets)
+#' # download station locations for 240, 241 (use as catchment outlets)
 #' ff <- "gs_weirs.GeoJSON"
 #' gs_fn <- file.path(saga_wd, ff)
 #' gs_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
-#' stns <- ch_get_url_data(gs_url, gs_fn)
+#' stns <- ch_get_url_data(gs_url, gs_fn)[1:2,]
 #' 
 #' # determine contributing area raster using filled_dem
 #' carea <- ch_saga_carea(filled_dem, saga_wd)
 #' 
 #' # run catchment delineation
-#' catchments <-  ch_saga_catchment(dem=dem, saga_wd=saga_wd, outlet=stns, carea=carea)
+#' catchments <-  ch_saga_catchment(dem=filled_dem, saga_wd=saga_wd, outlet=stns, carea=carea)
 #' 
 #' # check catchments
 #' ch_checkcatchment(filled_dem, catchments, stns)

--- a/R/ch_checkchannels.R
+++ b/R/ch_checkchannels.R
@@ -5,7 +5,7 @@
 #' This function generates a simple map of the drainage network plotted over the contours to allow a visual assessment.
 #' 
 #' @param dem Raster. DEM catchment was generated from
-#' @param channels sf. channel polyline
+#' @param channels sf. channel polyline (or channels list from \code{ch_saga_channels})
 #' @param outlet sf. location of catchment outlet
 #' @return 
 #' \item{check_map}{generates map with channel layer}
@@ -15,15 +15,52 @@
 #' 
 #' 
 #' @examples 
+#' @examples
+#' 
 #' \dontrun{
-#' map <-  ch_checkchannels(dem, channels, outlet)
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires multiple potentially lengthy GIS operations
+#' 
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # fill sinks
+#' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
+#' 
+#' # determine contributing area raster using filled_dem
+#' carea <- ch_saga_carea(filled_dem, saga_wd)
+#' 
+#' # generate channels sf object
+#' channels <- ch_saga_channels(dem=filled_dem, saga_wd=saga_wd, carea=carea)
+#' 
+#' # download station locations (use as catchment outlets)
+#' ff <- "gs_weirs.GeoJSON"
+#' gs_fn <- file.path(saga_wd, ff)
+#' gs_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' stns <- ch_get_url_data(gs_url, gs_fn)
+#' 
+#' # check channels
+#' ch_checkchannels(dem, channels, outlet=stns)
 #' }
 #' 
-#' @importFrom sf st_bbox
+#' @importFrom sf st_bbox st_geometry
 #' @importFrom ggplot2 ggplot geom_sf coord_sf theme_bw 
 #' @importFrom ggspatial annotation_north_arrow annotation_scale north_arrow_fancy_orienteering
 #' @export
-ch_checkchannels <- function(dem, channels, outlet) {
+ch_checkchannels <- function(channels, dem, outlet) {
+  
+  # add handling for directly passing output from ch_saga_channels function
+  if (class(channels) == "list" & "channels" %in% names(channels)) {
+    channels <- channels$channels
+  }
   
   contours <- ch_contours(dem)
   # get bounding box for contours to set map limits

--- a/R/ch_checkchannels.R
+++ b/R/ch_checkchannels.R
@@ -48,14 +48,14 @@
 #' stns <- ch_get_url_data(gs_url, gs_fn)
 #' 
 #' # check channels
-#' ch_checkchannels(dem, channels, outlet=stns)
+#' ch_checkchannels(dem=filled_dem, channels, outlet=stns)
 #' }
 #' 
 #' @importFrom sf st_bbox st_geometry
 #' @importFrom ggplot2 ggplot geom_sf coord_sf theme_bw 
 #' @importFrom ggspatial annotation_north_arrow annotation_scale north_arrow_fancy_orienteering
 #' @export
-ch_checkchannels <- function(channels, dem, outlet) {
+ch_checkchannels <- function(dem, channels, outlet) {
   
   # add handling for directly passing output from ch_saga_channels function
   if (class(channels) == "list" & "channels" %in% names(channels)) {

--- a/R/ch_clear_wd.R
+++ b/R/ch_clear_wd.R
@@ -13,8 +13,15 @@
 #' @seealso \code{\link{ch_create_wd}} to create working SAGA directory
 #' @export
 #' @examples \dontrun{
-#' # clear the current working directory
-#' ch_clear_wd(getwd())
+#' 
+#' # not run as clearing all files in a given directory cannot be tested in CRAN
+#' 
+#' # create a saga working directory
+#' saga_wd <- tempdir()
+#' ch_create_wd(saga_wd) # confirm creation
+#' 
+#' # clear the saga working directory
+#' ch_clear_wd(saga_wd)
 #' }
 #' 
 ch_clear_wd <- function(wd) {

--- a/R/ch_contours.R
+++ b/R/ch_contours.R
@@ -19,8 +19,27 @@
 #' @seealso \code{\link{ch_saga_fillsinks}} to fill sinks instead of removing
 #' 
 #' @examples
+#' 
 #' \dontrun{
-#' ch_contours()
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires multiple potentially lengthy GIS operations
+#' 
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # generate contours
+#' contours <- ch_contours(dem)
+#' 
+#' # plot contours map
+#' plot(contours)
 #' }
 #' 
 #' @importFrom raster raster getValues rasterToContour crs

--- a/R/ch_create_wd.R
+++ b/R/ch_create_wd.R
@@ -10,10 +10,7 @@
 #' @seealso \code{\link{ch_clear_wd}} to clear the working SAGA directory
 #' @export
 #' @examples
-#' \dontrun{
-#' ch_create_wd()
-#' 
-#' }
+#' ch_create_wd(tempdir())
 #' 
 ch_create_wd <- function(wd) {
   # creates working directory for saga files

--- a/R/ch_get_url_data.R
+++ b/R/ch_get_url_data.R
@@ -16,8 +16,11 @@
 #'or an \code{sf} object (from a GeoJSON file).
 #'
 #' @examples
-#'# Tested using files in the Upper Penticton Creek
-#'# zenodo repository https://zenodo.org/record/4781469
+#' \dontrun{
+#' # example not run since multiple large data files are downloaded
+#' 
+#' # Tested using files in the Upper Penticton Creek
+#' # zenodo repository https://zenodo.org/record/4781469
 #' library(ggplot2)
 #' library(here)
 #' library(raster)
@@ -27,24 +30,24 @@
 #' if (!dir.exists(dir_name)) {
 #'   dir.create(dir_name)
 #' }
-# 
+#'  
 #' # test with soil moisture data in csv format
 #' sm_fn <- here("test_data", "sm_data.csv")
 #' sm_url <- "https://zenodo.org/record/4781469/files/sm_data.csv"
 #' sm_data <- ch_get_url_data(sm_url, sm_fn)
 #' head(sm_data)
-# 
+#' 
 #' # test with tif/tiff file containing a dem
 #' ra_fn <- here("test_data", "gs_dem25.tif")
 #' ra_url <- "https://zenodo.org/record/4781469/files/gs_dem25.tif"
 #' ra_data <- ch_get_url_data(ra_url, ra_fn)
 #' plot(ra_data)
-# 
+#' 
 #' # test with GeoJSON
 #' gs_fn <- here("test_data", "gs_soilmaps.GeoJSON")
 #' gs_url <- "https://zenodo.org/record/4781469/files/gs_soilmaps.GeoJSON"
 #' gs_data <- ch_get_url_data(gs_url, gs_fn)
-# 
+#' 
 #' ggplot(gs_data) +
 #'   geom_sf(aes(fill = new_key)) +
 #'   labs(fill = "Soil class",
@@ -52,7 +55,7 @@
 #'        y = "UTM Northing (m)") +
 #'   coord_sf(datum = 32611) +
 #'   theme_bw()
-#'   
+#' }
 #' @export
 #' 
 ch_get_url_data <- function(gd_url, gd_filename) {

--- a/R/ch_saga_carea.R
+++ b/R/ch_saga_carea.R
@@ -23,7 +23,29 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' ch_saga_carea()
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires a potentially lengthy GIS operation
+#' 
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # fill sinks
+#' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
+#' 
+#' # determine contributing area raster using filled_dem
+#' carea <- ch_saga_carea(filled_dem, saga_wd)
+#' 
+#' # plot contributing area raster
+#' library(raster)
+#' plot(carea)
 #' }
 #' 
 ch_saga_carea <- function(dem, saga_wd, 

--- a/R/ch_saga_carea.R
+++ b/R/ch_saga_carea.R
@@ -31,8 +31,8 @@
 #' # create saga wd using base::tempdir()
 #' saga_wd <- tempdir()
 #'
-#' # download 25m DEM
-#' ff <- "gs_dem25.tif"
+#' # download LiDAR DEM for 240 and 241 creek
+#' ff <- "gs_be240.tif"
 #' ra_fn <- file.path(saga_wd, ff)
 #' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
 #' dem <- ch_get_url_data(ra_url, ra_fn)

--- a/R/ch_saga_catchment.R
+++ b/R/ch_saga_catchment.R
@@ -47,9 +47,9 @@
 #' 
 #' # create saga wd using base::tempdir()
 #' saga_wd <- tempdir()
-#'
-#' # download 25m DEM
-#' ff <- "gs_dem25.tif"
+#' 
+#' # download LiDAR DEM for 240 and 241 creek
+#' ff <- "gs_be240.tif"
 #' ra_fn <- file.path(saga_wd, ff)
 #' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
 #' dem <- ch_get_url_data(ra_url, ra_fn)
@@ -57,17 +57,17 @@
 #' # fill sinks
 #' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
 #' 
-#' # download station locations (use as catchment outlets)
+#' # download station locations for 240, 241 (use as catchment outlets)
 #' ff <- "gs_weirs.GeoJSON"
 #' gs_fn <- file.path(saga_wd, ff)
 #' gs_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
-#' stns <- ch_get_url_data(gs_url, gs_fn)
+#' stns <- ch_get_url_data(gs_url, gs_fn)[1:2,]
 #' 
 #' # determine contributing area raster using filled_dem
 #' carea <- ch_saga_carea(filled_dem, saga_wd)
 #' 
 #' # run catchment delineation
-#' catchments <-  ch_saga_catchment(dem=dem, saga_wd=saga_wd, outlet=stns, carea=carea)
+#' catchments <-  ch_saga_catchment(dem=filled_dem, saga_wd=saga_wd, outlet=stns, carea=carea)
 #' }
 #' 
 ch_saga_catchment <- function(dem, saga_wd, outlet,

--- a/R/ch_saga_catchment.R
+++ b/R/ch_saga_catchment.R
@@ -38,11 +38,36 @@
 #' @seealso \code{\link{ch_saga_fillsinks}} to fill sinks instead of removing
 #' @export
 #' @examples
-#' \dontrun{
-#' ch_saga_catchment()
 #' 
-#' # consider sample DEM data with this
-#  # https://github.com/wcmbishop/rayshader-demo/blob/master/R/elevation-api.R
+#' \dontrun{
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires multiple potentially lengthy GIS operations
+#' 
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # fill sinks
+#' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
+#' 
+#' # download station locations (use as catchment outlets)
+#' ff <- "gs_weirs.GeoJSON"
+#' gs_fn <- file.path(saga_wd, ff)
+#' gs_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' stns <- ch_get_url_data(gs_url, gs_fn)
+#' 
+#' # determine contributing area raster using filled_dem
+#' carea <- ch_saga_carea(filled_dem, saga_wd)
+#' 
+#' # run catchment delineation
+#' catchments <-  ch_saga_catchment(dem=dem, saga_wd=saga_wd, outlet=stns, carea=carea)
 #' }
 #' 
 ch_saga_catchment <- function(dem, saga_wd, outlet,
@@ -56,9 +81,11 @@ ch_saga_catchment <- function(dem, saga_wd, outlet,
     print("saga_wd does not exist")
     return(NA)
   }
+  
   # store the dem in the working directory
   raster::writeRaster(dem, paste0(saga_wd, "/dem.sdat"), format = "SAGA",
                       NAflag = -9999, overwrite = TRUE)
+  
   # if a contributing area raster was not included, create one
   if (is.null(carea)) {
     if (carea_flag == 0) {
@@ -117,7 +144,7 @@ ch_saga_catchment <- function(dem, saga_wd, outlet,
     }
   }
   # create data frame
-  catchment_sf <- data.frame(label = outlet_label,
+  catchment_sf <- data.frame(label = labels,
                              outlet_x = xy[, 1], outlet_y = xy[, 2]) %>%
     cbind(polygon_sfc) %>%
     st_as_sf()

--- a/R/ch_saga_channels.R
+++ b/R/ch_saga_channels.R
@@ -19,8 +19,8 @@
 #' @param carea_flag if carea = NULL, 0 = create carea from dem; 1 = read in carea.sdat
 #' @param saga_wd name of working directory
 #' @param out_shp if TRUE, return channel network as sf object
-#' @param out_ntwrk if TRUE, return specified object as a raster
-#' @param out_route if TRUE, return specified object as a raster
+#' @param out_ntwrk if TRUE, return specified object (channel network) as a raster
+#' @param out_route if TRUE, return specified object (channel route) as a raster
 #' @param initvalue parameters for SAGA function
 #' @param initmethod parameters for SAGA function
 #' @param divcells parameters for SAGA function
@@ -38,11 +38,30 @@
 #' @seealso For more details, see the following: (http://www.saga-gis.org/saga_tool_doc/2.2.5/ta_channels_0.html)
 #' @export
 #' @examples
-#' \dontrun{
-#' ch_saga_carea()
 #' 
-#' # consider sample DEM data with this
-#  # https://github.com/wcmbishop/rayshader-demo/blob/master/R/elevation-api.R
+#' \dontrun{
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires multiple potentially lengthy GIS operations
+#' 
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # fill sinks
+#' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
+#' 
+#' # determine contributing area raster using filled_dem
+#' carea <- ch_saga_carea(filled_dem, saga_wd)
+#' 
+#' # generate channels sf object
+#' channels <- ch_saga_channels(dem=filled_dem, saga_wd=saga_wd, carea=carea)
 #' }
 #' 
 ch_saga_channels <- function(dem, saga_wd, carea = NULL, carea_flag = 0,

--- a/R/ch_saga_fillsinks.R
+++ b/R/ch_saga_fillsinks.R
@@ -24,10 +24,26 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' ch_saga_fillsinks()
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires a potentially lengthy GIS operation
 #' 
-#' # consider sample DEM data with this
-#  # https://github.com/wcmbishop/rayshader-demo/blob/master/R/elevation-api.R
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # fill sinks
+#' filled_dem <-  ch_saga_fillsinks(dem_raw=dem, saga_wd=saga_wd)
+#' 
+#' # plot the difference in raw and filled dem (positive -> filled)
+#' library(raster)
+#' plot(filled_dem-dem)
 #' }
 #' 
 ch_saga_fillsinks <- function(dem_raw, saga_wd, 

--- a/R/ch_saga_removesinks.R
+++ b/R/ch_saga_removesinks.R
@@ -16,10 +16,26 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' ch_saga_removesinks()
+#' # note: example not run in package compilation
+#' # - requires creating and accessing a temporary directory
+#' # - requires downloading spatial data from Zenodo repository
+#' # - requires a potentially lengthy GIS operation
 #' 
-#' # consider sample DEM data with this
-#  # https://github.com/wcmbishop/rayshader-demo/blob/master/R/elevation-api.R
+#' # create saga wd using base::tempdir()
+#' saga_wd <- tempdir()
+#'
+#' # download 25m DEM
+#' ff <- "gs_dem25.tif"
+#' ra_fn <- file.path(saga_wd, ff)
+#' ra_url <- sprintf("https://zenodo.org/record/4781469/files/%s",ff)
+#' dem <- ch_get_url_data(ra_url, ra_fn)
+#' 
+#' # remove sinks
+#' removed_dem <-  ch_saga_removesinks(dem_raw=dem, saga_wd=saga_wd)
+#' 
+#' # plot the difference in raw and sink-removed dem 
+#' library(raster)
+#' plot(removed_dem-dem)
 #' }
 #' 
 ch_saga_removesinks <- function(dem_raw, saga_wd, 


### PR DESCRIPTION
Updated the examples in changed functions, making use of ch_url_getdata for retrieving Upper Penticton example data.

Update from previous pull request to use LiDAR DEM in catchment delineation examples and other areas as appropriate. Note that the CDEM 25m resolution is still used in some examples (such as ch_contours, ch_saga_channels) where the 25m DEM is adequate for demonstration and where the LiDAR DEM resolution is prohibitive for runtimes.

All spatial examples still use \dontrun to avoid issues with CRAN checks due to long example run times