### PR TITLE
updated version number and date, and fixed checking bug in ch_tidyhyd…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: CSHShydRology
 Title: Canadian Hydrological Analyses
-Version: 1.1.3
-Date: 2021-10-22
+Version: 1.2.0
+Date: 2021-11-05
 Authors@R: c(person("Kevin", "Shook", 
               email = "kevin.shook@usask.ca", 
               role = c("cre", "aut")),

--- a/R/ch_tidyhydat_ECDE_meta.R
+++ b/R/ch_tidyhydat_ECDE_meta.R
@@ -61,11 +61,14 @@
 #' @importFrom utils txtProgressBar setTxtProgressBar
 #' @seealso \code{\link{ch_get_ECDE_metadata}} \code{\link{ch_tidyhydat_ECDE}}
 #' @examples 
+#' \dontrun{
+#' # This example is disabled as it requires \pkg{tidyhydat} to have installed
+#' # the \code{HYDAT} database, which makes automatic checking slow
 #' stations <- c("05BB001", "05BB003", "05BB004", "05BB005")
 #' result <- ch_tidyhydat_ECDE_meta(stations)
 #' metadata <- result[[1]]
 #' version <- result[[2]]
-#' 
+#' }
 #' \dontrun{
 #' # This example is not run, as it can take over an hour to execute
 #' # It is intended to be used by the package maintainers to update HYDAT_list,

--- a/man/ch_tidyhydat_ECDE_meta.Rd
+++ b/man/ch_tidyhydat_ECDE_meta.Rd
@@ -59,11 +59,14 @@ of many fields such as operating schedule. Returning these values slows the func
 particularly when all WSC stations are selected.
 }
 \examples{
+\dontrun{
+# This example is disabled as it requires \pkg{tidyhydat} to have installed
+# the \code{HYDAT} database, which makes automatic checking slow
 stations <- c("05BB001", "05BB003", "05BB004", "05BB005")
 result <- ch_tidyhydat_ECDE_meta(stations)
 metadata <- result[[1]]
 version <- result[[2]]
-
+}
 \dontrun{
 # This example is not run, as it can take over an hour to execute
 # It is intended to be used by the package maintainers to update HYDAT_list,


### PR DESCRIPTION
…at_ECDE_meta

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- made the first example in ch_tidyhydat_ECDE_meta \dontrun to avoid errors generated when checking
- in DESCRIPTION set version to 1.2.0 and date to today
- package now checks on https://win-builder.r-project.org/, with 2 "issues" being that it thinks "hydrological" is misspelled!
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
