### PR TITLE
Updates to eccc_single_station function based on comments

### DIFF
--- a/R/get_eccc_single_station.R
+++ b/R/get_eccc_single_station.R
@@ -1,72 +1,170 @@
 #' Extracting Single Station ECCC meteorological data using an API
 #'
 #' This function performs the API request to pull meteorological data for single stations from
-#' Environment and Climate Change Canada (ECCC) using the OGC API for a single station 
+#' Environment and Climate Change Canada (ECCC) using the OGC API for a single station.
+#' 
+#' These function pull data by the stations ClimateID number. The climate ID number can be found
+#' by searchin the station on the historical data page on the ECCC website (https://climate.weather.gc.ca/historical_data/search_historic_data_e.html) 
+#' and searching for your station. The resulting page will display the Climate ID of the station. 
+#' 
+
+#' 
+#' 
+#' @param station_ClimateID The Climate id type used to define the station.
+#' @param res Resolution of data options -> "hourly", "daily", "monthly".
+#' @param dt_start Starting datetime of data to extract.
+#'      Options -> string with format YYYY-MM-DDThh:mm:ss OR NULL to signify start of record.
+#' @param dt_end Ending datetime of data to extract. 
+#'      Options -> string with format YYYY-MM-DDThh:mm:ss OR NULL to signify current date time.
+#' @param sortby The variable you want to sort the results by. 
+#'        It must match a column name that is returned in the data set.
+#' @return
+#' A data frame containing all records and feature values from the specified station and dates.
 #'
-#' @param station_ClimateID The Climate id type used to define the station
-#' @param res Resolution of data options -> "hourly", "daily", "monthly"
+#' @examples
+#' not run here
+
+request_eccc_data <- function(station_ClimateID, res,offset,limit,dt_start,dt_end, on_failure = NULL){
+  #create URL
+  url <- paste0("https://api.weather.gc.ca/collections/", 
+                "climate-", res, "/items?f=csv&",
+                "limit=", format(limit, scientific = FALSE),
+                "&offset=", format(offset, scientific = FALSE),
+                "&lang=en-CA&skipGeometry=false",
+                "&sortby=LOCAL_DATE",
+                "&datetime=",dt_start, "/", dt_end,
+                "&CLIMATE_IDENTIFIER=", station_ClimateID)
+  ec_data <- try(read.csv(url))
+  
+  # if error is received on URL call
+  if (inherits(ec_data, "try-error")) {
+    if (is.null(on_failure)){
+      return (list(NULL,0))
+    } else {
+    stop(paste0("API call failed; ",url))
+    }
+  }
+  
+  return(list(ec_data, nrow(ec_data)))
+}
+
+#'Format date for API Call
+#'
+#'Formats the date to make an appropriate API call. If daily resolution,
+#'the date entered will be set to the zero-th hour for the day. If monthly resolution, the
+#'date entered will be set transformed to the first day of the month. If hourly resolution, the 
+#'datetime entered will be set to the top of the hour. 
+#'
+#' @param dt The datetime object to be transformed. Can be in POSIXt format or a string. 
+#' @param res The resolution of the data to be extracted from the API
+#' 
+#'  @return 
+#'  A string formatted to use in the API call 
+
+format_date <- function(dt, res) {
+  # API syntax for no start and/or end date
+  if (is.null(dt)){
+    return (NULL)
+    
+  # if data is read is POSIXt
+  }else if (inherits(dt, "POSIXt")){
+    if (res == 'daily'){
+      dt = format(dt, format ="%Y-%m-%dT00:00:00")
+    } else if (res == 'monthly'){
+      dt= format(dt, format = "%Y-%m-01T00:00:00")
+    } else if (res == 'hourly'){
+      dt = format(dt, format = "%Y-%m-%dT%H:00:00")
+    }
+    
+  # if date is string  
+  } else if (inherits(dt, "character")){
+    
+    # check string is in correct structure
+    parsed <- as.POSIXct(as.POSIXlt(dt, tryFormats = c("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H", "%Y-%m-%d"), tz = "UTC"))
+    # check the format of a sting input
+    if (is.na(parsed)){
+      stop(
+        structure(
+          list(message = "The inputs dt_start and/or dt_end are not in a related format to '%Y-%m-%dT%H:%M:%S'", call = NULL),
+          class = c("invalid_formatting", "error", "condition")
+        )
+      )
+    }
+    
+    # update based in data resolution
+    if (res == 'daily'){
+      dt = format(parsed, format ="%Y-%m-%dT00:00:00")
+    } else if (res == 'monthly'){
+      dt= format(parsed, format = "%Y-%m-01T00:00:00")
+    } else if (res == 'hourly'){
+      dt = format(parsed, format = "%Y-%m-%dT%H:00:00")
+    }
+    
+  }
+  
+  return (dt)
+}
+
+#' Extracting Single Station ECCC meteorological data using an API
+#'
+#' This function performs the API request to pull meteorological data for single stations from
+#' Environment and Climate Change Canada (ECCC) using the OGC API for a single station.
+#' 
+#' #' API Swagger Page: https://api.weather.gc.ca/openapi?f=html#/climate-daily/getClimate-dailyFeatures
+#' 
+
+#' @param station_ClimateID The Climate ID  used to define the station.The climate ID number can be found
+#' by searchin the station on the historical data page on the ECCC website (https://climate.weather.gc.ca/historical_data/search_historic_data_e.html) 
+#' and searching for your station. The resulting page will display the Climate ID of the station. 
+#' @param res Resolution of data options -> "hourly", "daily", "monthly". 
 #'   \itemize{
 #'     \item `"hourly"`: Data extracted at hourly resolution
 #'     \item `"daily"`: Data extracted at daily resolution
 #'     \item `"monthly"`: Data extracted at monthly resolution
 #'   }
-#' @param dt_start Starting datetime of data to extract
-#'      Options -> string with format YYYY-MM-DDThh:mm:ss OR '..' to signify start of record
-#' @param dt_end Ending datetime of data to; 
-#'      Options -> string with format YYYY-MM-DDThh:mm:ss OR '..' to signify current date time
-#' @param sortby The variable you want to sort the results by. 
-#'        It must match a column name that is returned in the data set
-#' @param API_limit The number of records a single API call will pull. Must be less than 10001
-#' @param API_offset The number of records to offset in a single pull. To pull all records, set this to 0
-#' @param verbose Logical value indicating if progress messages are displayed
+#' @param dt_start Starting date-time for the data to extract. Must be either a character string in ISO 8601 format (e.g., "YYYY-MM-DDThh:mm:ss", with partial formats such as "YYYY-MM" or "YYYY-MM-DD" also accepted) or an object of class POSIXt. 
+#' At least one of dt_start or dt_end must be non-NULL.
+#' @param dt_end Ending date-time for the data to extract. Must be either a character string in ISO 8601 format (e.g., "YYYY-MM-DDThh:mm:ss", with partial formats such as "YYYY-MM" or "YYYY-MM-DD" also accepted) or an object of class POSIXt. 
+#' At least one of dt_start or dt_end must be non-NULL.
+#' @param verbose Logical value indicating if progress messages are displayed. Note that the API call may still print progress statements even if 
+#' verbose is set to FALSE.
 #'
 #' @return
-#' A data frame containing all records and feature values from the specified station and dates
+#' A data frame containing all records and feature values from the specified station and dates.
 #'
 #' @examples
-#' get_eccc_single_station(station_ClimateID = "1026271", dt_start = "2024-01-01T00:00:00", dt_end= "..")
+#' Not run here
 #'
 #' @export
-
 get_eccc_single_station <- function(station_ClimateID, 
-                         res = "daily", 
+                         res = c("daily","hourly","monthly"),
                          dt_start = "1840-01-01T00:00:00",
-                         dt_end = "..",
+                         dt_end = NULL,
                          sortby = 'LOCAL_DATE',
                          API_limit = 10000,
-                         API_offset = 0,
-                         verbose = TRUE){
+                         verbose = FALSE,
+                         on_failure = NULL){
+  # seconds until operation times out (4mins). Ensures it doesn't get stuck on bad API call
+  options(timeout = 240) 
   
-  # This performs the API request
-  request_eccc_data <- function(station_ClimateID,res,offset,limit,id_type,dt_start,dt_end){
-    url <- paste0("https://api.weather.gc.ca/collections/", 
-                  "climate-", res, "/items?f=csv&",
-                  "limit=", format(limit, scientific = FALSE),
-                  "&offset=", format(offset, scientific = FALSE),
-                  "&lang=en-CA&skipGeometry=false",
-                  "&sortby=",sortby,
-                  "&datetime=",dt_start, "/", dt_end,
-                  "&CLIMATE_IDENTIFIER=", station_ClimateID)
-    ec_data <- try(fread(url))
-    if (inherits(ec_data, "try-error")) {
-      stop(paste0("API call failed; ",url))
-    }
-    return(list(ec_data, nrow(ec_data)))
-  }
-    
-  options(timeout = 240) # seconds until operation times out (4mins)
+  # set API call limit (as of Aug 2026, limit is 10,000)
+  API_offset = 0
+  API_limit = 8000
   
-  # 1. Check dt_start and dt_end are character
-  if (!inherits(dt_start, "character") || !inherits(dt_end, "character")) {
+  res <- match.arg(res)
+  
+  # both the start and end date cannot be null (API does not allow for this)
+  if (is.null(dt_start) && is.null(dt_end)){
     stop(
       structure(
-        list(message = "ERROR: dt_start and/or dt_end not character variables. Must be a string", call = NULL),
-        class = c("not_character", "error", "condition")
+        list(message = "Both arguments dt_start and dt_end are NULL. Please define one or both.", call = NULL),
+        class = c("invalid_formatting", "error", "condition")
       )
     )
-  }
+  } 
   
-  # 2. Check verbose is logical
+  
+  # Check verbose is logical
   if (!inherits(verbose, "logical")) {
     stop(
       structure(
@@ -76,100 +174,42 @@ get_eccc_single_station <- function(station_ClimateID,
     )
   }
   
-  # 3. Check res is valid
-  if (length(res) != 1 || !(res %in% c("hourly", "daily", "monthly"))) {
-    stop(
-      structure(
-        list(message = "Argument 'res' must be one of: 'hourly', 'daily', or 'monthly'", call = NULL),
-        class = c("invalid_argument", "error", "condition")
-      )
-    )
-  }
-  
-  # 4. Check dt_start and dt_end are not both ".."
-  dt_format <- "%Y-%m-%dT%H:%M:%S"
-  if ((length(dt_start) != 1 || length(dt_end) != 1) || (dt_start == ".." && dt_end == "..")) {
-    stop(
-      structure(
-        list(message = "Both arguments dt_start and dt_end are '..'. Please define one or both.", call = NULL),
-        class = c("invalid_formatting", "error", "condition")
-      )
-    )
-  }
-  
-  # 5. Parse dates
-  dt_start_a <- strptime(dt_start, format = dt_format)
-  dt_end_a <- strptime(dt_end, format = dt_format)
-  
-  # 6. Check both dates are not NA
-  if ((length(dt_start_a) != 1 || length(dt_end_a) != 1) || (is.na(dt_start_a) && is.na(dt_end_a))) {
-    stop(
-      structure(
-        list(message = "Both arguments dt_start and dt_end have invalid formatting. Ensure they follow '%Y-%m-%dT%H:%M:%S'.", call = NULL),
-        class = c("invalid_formatting", "error", "condition")
-      )
-    )
-  }
-  
-  dotdot <- 0
-  
-  # 7. Check dt_start_a NA but dt_end_a valid
-  if (is.na(dt_start_a) && !is.na(dt_end_a)) {
-    if (dt_start != "..") {
+  # format date for API call
+  dt_start <- format_date(dt_start,res)
+  dt_end <- format_date(dt_end,res)
+
+  # make sure start date comes before end date  
+  if (!is.null(dt_start) && !is.null(dt_end)){
+    if (dt_start > dt_end){
       stop(
         structure(
-          list(message = "ERROR: Argument dt_start has invalid formatting. Ensure it follows the format %Y-%m-%dT%H:%M:%S", call = NULL),
-          class = c("invalid_formatting", "error", "condition")
+          list(message = "Argument dt_start must be less than dt_end.", call = NULL),
+          class = c("invalid_range", "error", "condition")
         )
       )
-    } else {
-      dotdot <- 1
     }
   }
   
-  # 8. Check dt_end_a NA but dt_start_a valid
-  if (is.na(dt_end_a) && !is.na(dt_start_a)) {
-    if (dt_end != "..") {
-      stop(
-        structure(
-          list(message = "ERROR: Argument dt_end has invalid formatting. Ensure it follows the format %Y-%m-%dT%H:%M:%S", call = NULL),
-          class = c("invalid_formatting", "error", "condition")
-        )
-      )
-    } else {
-      dotdot <- 2
-    }
+  # Format null start/end date to '..' (what the API formats Null as)
+  if (is.null(dt_start)){
+    dt_start = ".."
   }
-  
-  # 9. Check dt_start_a < dt_end_a
-  if (dotdot == 0 && !is.na(dt_start_a) && !is.na(dt_end_a) && dt_start_a > dt_end_a) {
-    stop(
-      structure(
-        list(message = "Argument dt_start must be less than dt_end.", call = NULL),
-        class = c("invalid_range", "error", "condition")
-      )
-    )
-  }
-  
-  # 10. Check API_limit
-  if (!inherits(API_limit, "numeric") || length(API_limit) != 1 || API_limit > 10000 || API_limit < 1) {
-    stop(
-      structure(
-        list(message = "Argument API_limit must be between 1 and 10000.", call = NULL),
-        class = c("invalid_range", "error", "condition")
-      )
-    )
+  if (is.null(dt_end)){
+    dt_end = ".."
   }
 
-  if (verbose == TRUE){
+  # print statement if verbose is true
+  if (verbose){
     print("All variables pass validity checks")
   }
   
-  returned_data <- request_eccc_data(station_ClimateID,res,API_offset,API_limit,id_type,dt_start,dt_end)
-  ec_data <- bind_rows(returned_data[1])
+  # make first request to ECCC using API
+  returned_data <- request_eccc_data(station_ClimateID,res,API_offset,API_limit,dt_start,dt_end)
+  ec_data <- dplyr::bind_rows(returned_data[1])
   number_records_returned <- returned_data[2]
 
-  if (verbose == TRUE){
+  # print statement if verbose is true
+  if (verbose){
     print(paste0("Request 1 Complete:",number_records_returned," records were returned"))
   }
   if (number_records_returned == 0){
@@ -180,13 +220,12 @@ get_eccc_single_station <- function(station_ClimateID,
   # If the API response limit is reached, we add an offset and pull the next records, appending the response to the dataframe
   while (number_records_returned == API_limit){
     API_offset = API_offset+API_limit
-    returned_data <- request_eccc_data(station_ClimateID,res,API_offset,API_limit,id_type,dt_start,dt_end)
+    returned_data <- request_eccc_data(station_ClimateID,res,API_offset,API_limit,dt_start,dt_end)
     ec_data_additional <- returned_data[1]
     number_records_returned <- returned_data[2]
-    ec_data <- bind_rows(ec_data, ec_data_additional)
+    ec_data <- dplyr::bind_rows(ec_data, ec_data_additional)
     count = count + 1
     print(paste0("Request ",count," Complete:",number_records_returned," records were returned"))
   }
-  
   return(ec_data)
 }


### PR DESCRIPTION
@KevinShook , vincenzocoia
Thanks so much for all the suggestions and comments you provided! They have all been addressed (see below for details). Here is a summary of the larger changes: 
1. I created a new function for formatting the inputted start and end datetime into the correct format for the API. This function also resolves the issues surrounding unexpected results depending on the combination of the start/end time and the data resolution of interest. The user can also now enter a string or POSITx object as the start and end dates.
2. The issues of reliance on the API are a definite concern. I have removed the tests for the function so they do not cause problems on CRAN. I noticed the majority of the functions do not have tests, so leaving out a test seemed appropriate (please let me know if this is not okay). I also left it out examples in the function description. 

**Updates made from reviewer comments**
1. Internal function request_eccc_data() updates
- The residual argument id_type is removed.
- Function has been moved outside of main function (with no @export decoratior).
- New argument added that allows user to determine what response they get if the API call fails (NULL result or an error message).

3. Start and End date behavior updates (all resolved within new function format_date())
- dt_start and dt_end can be either strings or a POSIXt object (prior it only allowed string entries) .
- No matter the granularity of the start and end date, the function will format it properly for the API call (i.e. user can now enter just year-month-day without a timestamp).
- Formats date based on the temporal resolution of the data being pulled. This resolved the issue if entering a start date of Jan 2 and getting returned monthly data starting in February.
- ‘..’ as a blank start and/or end date is how the API requires it to be written. However, the argument is now entered as None and transformed to ‘..’ for the API call to keep it more intuitive for the user. 
- The start date and end date cannot both be null, as the API call will error. I have added a check for this from the users inputs as well as made note in the documentation.  The start date chosen for the default argument value is arbitrarily chosen to be far enough in the past to ensure all data is being pulled if the start date is not entered by the user. 

4. Argument Updates
- The default value for the argument “verbose” is now false. Extra notes have been added that indicate the API call itself may print out statements regardless of these verbose arguments value as verbose indicates if status updates for the code are being printed. There is no verbose argument that can be set for the API call itself.  
- I removed the API limit and API offset arguments. The target user of this function is someone who does not know how an API works. The API_limit and API_offset are used to ensure we are extracting all the data properly. The ECCC API is very straightforward so if a user needs a more complex API call where they dictate limit and offset, they will likely have the skills to code a simple API script.
- Used arg.match() to ensure users are entering in the resolution argument from a selected list of values (“daily, “monthly”, “hourly”)

5. Documentation updates
- Added information in the function documentation how to find the climate ID for a given station on the ECCC website
- Link to ECCC API documentation has been added to script documentation
- Proper punctuation has been added to all documentation

6. Other Updates
- Removed the dependency on data.table. I now use read.csv() for consistency across functions. 
- Utilization of :: is now correct
- Removed redundancy of if (verbose == True)
