### PR TITLE
fixed typo causing error when ch_read_AHCCD_monthly read Tmin values

### DIFF
--- a/R/ch_read_AHCCD_monthly.R
+++ b/R/ch_read_AHCCD_monthly.R
@@ -50,7 +50,7 @@ ch_read_AHCCD_monthly <- function(monthly_file = NULL) {
     val_type <- 'tmean'
   }
   else if (str_detect(tolower(filename), 'mn')) {
-    vals_type <- 'tmin'
+    val_type <- 'tmin'
   } 
   else if (str_detect(str_to_lower(filename), "mt")) {
     val_type <- "precip"
@@ -72,7 +72,7 @@ ch_read_AHCCD_monthly <- function(monthly_file = NULL) {
   close(con)
   
   # find number of lines containing file info
-  # headerlines may be in English and/or French
+  # header lines may be in English and/or French
   
   input <- tolower(input)
   LineNum <- str_detect(input, fixed(','))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed a small typo (name of a variable) causing an error when reading monthly AHCCD Tmin values

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
